### PR TITLE
Refactor files method to use shutil

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,5 @@
 import json
-import subprocess
+import shutil
 from pathlib import Path
 
 import pytest
@@ -11,6 +11,7 @@ from rdmo.accounts.utils import set_group_permissions
 
 @pytest.fixture(scope='session')
 def django_db_setup(django_db_setup, django_db_blocker):
+    """Fixture to set up the database with fixtures and permissions."""
     with django_db_blocker.unblock():
         fixtures = []
         for fixture_dir in settings.FIXTURE_DIRS:
@@ -37,16 +38,18 @@ def django_db_setup(django_db_setup, django_db_blocker):
 
 @pytest.fixture
 def files():
-    def setup():
-        media_path = Path(__file__).parent / 'testing' / 'media'
-        subprocess.check_call(['rsync', '-a', '--delete', media_path.as_posix().rstrip('/') + '/', settings.MEDIA_ROOT.rstrip('/') + '/'])
+    """Fixture to create a temporary MEDIA_ROOT directory and copy test data into it."""
+    media_path = Path(__file__).parent / 'testing' / 'media'
+    media_root = Path(settings.MEDIA_ROOT)
 
-    setup()
-    return setup
+    if media_root.exists():
+        shutil.rmtree(media_root)
+    shutil.copytree(media_path, media_root)
 
 
 @pytest.fixture
 def json_data():
+    """Fixture to load json data from a file."""
     json_file = Path(settings.BASE_DIR) / 'import' / 'catalogs.json'
     json_data = {
         'elements': json.loads(json_file.read_text())


### PR DESCRIPTION
Refactor `files()` in `conftest.py` to use `shutil` for file operations, remove the nested `setup()` function, and add docstrings to all functions.

---
<a href="https://cursor.com/background-agent?bcId=bc-55ca365f-69b2-4661-8eb2-694ac4ebb05e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-55ca365f-69b2-4661-8eb2-694ac4ebb05e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

